### PR TITLE
Add a method to upload a representation to an entry

### DIFF
--- a/affectiva/api.py
+++ b/affectiva/api.py
@@ -149,3 +149,26 @@ class EmotionAPI:
         resp = requests.post(entry['annotations'], auth=self._auth, headers=ACCEPT_JSON, data={"annotation[source]": source, "annotation[key]": key, "annotation[value]": value})
         resp.raise_for_status()
         return resp.json()
+
+    def add_representation(self, entry, media_path, mimetype):
+        """Upload an additional representation to the provided entry.
+
+        Args:
+            entry: A dict containing the entry to which the
+              representation will be attached.
+            media_path: Path to local media file to be uploaded.  The
+              entry must not already have a representation with this
+              filename.
+            mimetype: A string with the representation's media type.
+
+        Example:
+        >>> from affectiva.api import EmotionAPI
+        >>> e = EmotionAPI()
+        >>> j = e.create_job('video1.mp4')
+        >>> e.add_representation(j['input'],'video2.mp4','application/vnd.affectiva.example+mp4')
+
+        """
+        metadata = {'media': (media_path, open(media_path, 'rb'), mimetype)}
+        resp = requests.post(entry['representation_self'], auth=self._auth, headers=ACCEPT_JSON, files=metadata)
+        resp.raise_for_status()
+        return resp.json()


### PR DESCRIPTION
This can be useful if you have two different encodings of the same
video, or a json-formatted data file and the same data in csv format.