### PR TITLE
Representation save_media()  fix

### DIFF
--- a/affectiva/api.py
+++ b/affectiva/api.py
@@ -1,6 +1,6 @@
-import requests
 import os
 
+import requests
 
 ACCEPT_JSON = {'Accept': 'application/json'}
 
@@ -146,7 +146,8 @@ class EmotionAPI:
         return resp.json()
 
     def add_annotation(self, entry, source, key, value):
-        resp = requests.post(entry['annotations'], auth=self._auth, headers=ACCEPT_JSON, data={"annotation[source]": source, "annotation[key]": key, "annotation[value]": value})
+        resp = requests.post(entry['annotations'], auth=self._auth, headers=ACCEPT_JSON,
+                             data={"annotation[source]": source, "annotation[key]": key, "annotation[value]": value})
         resp.raise_for_status()
         return resp.json()
 

--- a/affectiva/job.py
+++ b/affectiva/job.py
@@ -69,7 +69,9 @@ class Entry(Base):
         Returns:
              return list of representations.
         """
-        return [Representation(url=representation['self'], user=self._user,
+        return [Representation(url=representation['self'],
+                               media_url=representation['media'],
+                               user=self._user,
                                password=self._password) for representation in self._details['representations']]
 
     def length(self):


### PR DESCRIPTION
Fixing the Entry.representations() to properly initialize the media_urll so that Representation.save_media() works using representations returned by Entry objects.

Without the fix:

```
entry = affectiva.Entry( entry_url )
rep = entry.representations()[0]
rep.save_media( local_path )
```
Throws an Missing Schema exception from deep within requests... ultimately caused by using an empty url:

```
MissingSchema: Invalid URL '': No schema supplied. Perhaps you meant http://?
```