### PR TITLE
Added update_job to the api class so we can update the job_name

### DIFF
--- a/affectiva/api.py
+++ b/affectiva/api.py
@@ -82,6 +82,22 @@ class EmotionAPI:
         resp.raise_for_status()
         return resp.json()
 
+    def update_job(self, job_url, job_name=None):
+        """Update the job.
+
+        Args:
+        job_name: (optional) Which classifier set to use.See: http://developer.affectiva.com/eaasapi/
+
+        Returns:
+            JSON response with keys ['status', 'updated', 'name', 'author', 'self', 'published', 'input']
+        """
+        data = {}
+        if job_name is not None:
+            data['entry_job[name]'] = job_name
+        resp = requests.patch(job_url, auth=self._auth, data=data, headers=ACCEPT_JSON)
+        resp.raise_for_status()
+        return resp.json()
+
     def download_results(self, job_url, content_type='application/csv', output_dir='.'):
         """download results from a job and save locally.
 

--- a/affectiva/api.py
+++ b/affectiva/api.py
@@ -86,7 +86,7 @@ class EmotionAPI:
         """Update the job.
 
         Args:
-        job_name: (optional) Which classifier set to use.See: http://developer.affectiva.com/eaasapi/
+            job_name: (optional) Which classifier set to use. See: http://developer.affectiva.com/eaasapi/
 
         Returns:
             JSON response with keys ['status', 'updated', 'name', 'author', 'self', 'published', 'input']


### PR DESCRIPTION
Now we can update the job-name via:

```
from affectiva.api import EmotionAPI
api = EmotionAPI()   # assumes env variables are set
api.update_job( job_url, job_name='auto' )
```

Error behaviour:
400 response if you send the patch request with an empty data dictionary (e.g. don't give an updated job name)
422 response if you try an invalid job-name

Both are emitted from the underlying request, which I think is OK given this is a low-level library.