### PR TITLE
Deprecate job

### DIFF
--- a/affectiva/api.py
+++ b/affectiva/api.py
@@ -182,6 +182,14 @@ class EmotionAPI:
         for annotation in annotations:
             self.add_annotation(entry, annotation['source'], annotation['key'], annotation['value'])
 
+    def delete_annotation(self, entry, source, key):
+        """Delete an annotation from an entry."""
+        annotations = self.query_job(entry['annotations'])
+        for a in annotations:
+            if a['source'] == source and a['key'] == key:
+                resp = requests.delete(a['self'], auth=self._auth, headers=ACCEPT_JSON)
+                resp.raise_for_status()
+
     def add_representation(self, entry, media_path, mimetype):
         """Upload an additional representation to the provided entry.
         Args:

--- a/affectiva/job.py
+++ b/affectiva/job.py
@@ -1,6 +1,7 @@
 import requests
 import json
 import shutil
+import warnings
 
 
 ACCEPT_JSON = {'Accept': 'application/json'}
@@ -12,6 +13,9 @@ class Base(object):
     _password = ''
 
     def __init__(self, url=None, user=None, password=None):
+
+        warnings.warn('please use affectiva.api.EmotionAPI', DeprecationWarning)
+
         self._url = url
         self._user = user
         self._password = password

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.5',
+    version='0.0.6',
 
     description='Affectiva Emotion API Python library',
     long_description='This library allows Python programs to easily make use of the Affectiva Emotion API',


### PR DESCRIPTION
These changes let us move our code base to affectiva.api so we can at least consider how to remove affectiva.job, and we need to maintain only affectiva.api going forward.
