### PR TITLE
Modify create_job to send up the content_type to the emotion as a service api

### DIFF
--- a/affectiva/api.py
+++ b/affectiva/api.py
@@ -1,5 +1,5 @@
 import os
-
+import mimetypes
 import requests
 
 ACCEPT_JSON = {'Accept': 'application/json'}
@@ -66,9 +66,10 @@ class EmotionAPI(object):
         Returns:
              JSON response with keys: 'status', 'updated', 'name', 'author', 'self', 'published', 'input'
         """
+        mime_type = mimetypes.guess_type(media_path)[0]
         with open(media_path, 'rb') as video:
             files = {'entry_job[name]': (None, job_name),
-                     'entry_job[input]': (os.path.basename(media_path), video)}
+                     'entry_job[input]': (os.path.basename(media_path), video, mime_type)}
             resp = requests.post(self._job_url, auth=self._auth, headers=ACCEPT_JSON, files=files, data=extra_params)
             resp.raise_for_status()
             return resp.json()


### PR DESCRIPTION
Without this change it sends up a blank content type, which is not ideal because
the processing code uses this to determine if we need to transcode to the video
to MP4.

This will be a slight performance improvement because we will no longer be transcoding
to MP4 when we don't need to.