### PR TITLE
Large file support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
+requests_toolbelt
 flake8

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ setup(
     # The minimal requirements for the library .. list all the requirements in
     # requirements.txt
     install_requires=[
-       'requests'
+        'requests',
+        'requests_toolbelt'
     ],
 
     include_package_data=True


### PR DESCRIPTION
This change streams files up and down so we can move arbitrarily large files back and forth.  The one exception is results() which returns the json results, not a file handle, so we need to read them into memory.
