### PR TITLE
Fix module dependencies to require >= requests 2.18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     # The minimal requirements for the library .. list all the requirements in
     # requirements.txt
     install_requires=[
-        'requests',
+        'requests >= 2.18',
         'requests_toolbelt'
     ],
 


### PR DESCRIPTION
The library uses a feature that was released in requests 2.18.0

Using an earlier version of requests causes a bug:

```
Traceback (most recent call last):
  File "test.py", line 9, in <module>
    downloaded_video = api.download_representation(representation, output_dir='.')
  File "/usr/lib/python2.7/site-packages/affectiva/api.py", line 136, in download_representation
    self._download(representation['media'], fout)
  File "/usr/lib/python2.7/site-packages/affectiva/api.py", line 296, in _download
    with requests.get(url, auth=self._auth, stream=True) as media_resp:
AttributeError: __exit__
```

This change modifies the package so that installing it requires `requests` greater then 2.18.0